### PR TITLE
[UPDATE] Adjust dotenv configuration to load environment variables fr…

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -4,7 +4,7 @@ const env = process.env;
 
 if (env.NODE_ENV)
   dotEnv.config({ path: `src/app/environments/${env.NODE_ENV}.env` });
-else dotEnv.config({ path: '../../.env' });
+else dotEnv.config({ path: './.env' });
 
 export default {
   port: Number(env.PORT) || 3000,


### PR DESCRIPTION
…om a fallback path './.env' instead of '../../.env' when NODE_ENV is not set.